### PR TITLE
Use std:: versions of isinf and isnan

### DIFF
--- a/faster-rnnlm/rnnlm.cc
+++ b/faster-rnnlm/rnnlm.cc
@@ -13,6 +13,7 @@
 
 #include <string>
 #include <vector>
+#include <cmath>
 
 #include "faster-rnnlm/hierarchical_softmax.h"
 #include "faster-rnnlm/layers/interface.h"
@@ -445,9 +446,9 @@ void TrainLM(
     }
 
     Real ratio = bl_entropy / entropy;
-    if (isnan(entropy) || isinf(entropy) || !(ratio >= bad_ratio)) {
+    if (std::isnan(entropy) || std::isinf(entropy) || !(ratio >= bad_ratio)) {
       // !(ratio >= bad_ratio) will catch nan and inf even in fastmath mode
-      if (isnan(entropy) || isinf(entropy) || !(ratio >= awful_ratio)) {
+      if (std::isnan(entropy) || std::isinf(entropy) || !(ratio >= awful_ratio)) {
         fprintf(stderr, "\tAwful: Nnet rejected");
         nnet->ReLoad(model_weight_file);
       } else {


### PR DESCRIPTION
For whatever reason, accessing the C versions of these functions doesn't work under GCC-5.4 on Ubuntu 16.04. This works for me and should be more portable, but YMMV if this is important.