### PR TITLE
eigen archive moved to GitLab

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -29,7 +29,7 @@ else
     echo "Downloading Eigen library"
     fname="$version.tar.bz2"
     if [ ! -f "eigen.$fname" ]; then
-      if ! wget_or_curl "http://bitbucket.org/eigen/eigen/get/$fname" eigen.$fname; then
+      if ! wget_or_curl "https://gitlab.com/libeigen/eigen/-/archive/$version/eigen-$fname" eigen.$fname; then
           echo "Failed to download $fname"
           rm -f eigen.$fname
           exit 1


### PR DESCRIPTION
`eigen` library was moved from bitbucket.org to GitLab in Dec 2019.
[Source](https://eigen.tuxfamily.org/index.php?title=News:Migration_to_GitLab.com_scheduled_on_the_December_4th)